### PR TITLE
Add overlay to hero section

### DIFF
--- a/src/components/HeroSection.vue
+++ b/src/components/HeroSection.vue
@@ -1,7 +1,8 @@
 <template>
   <section class="hero">
-    <h1>{{ title }}</h1>
-    <p>{{ message }}</p>
+    <div class="overlay">
+      <p class="overlay-message">{{ message }}</p>
+    </div>
   </section>
 </template>
 
@@ -11,18 +12,30 @@ defineProps(['title', 'message'])
 
 <style scoped>
 .hero {
-  text-align: center;
-  padding: 3rem 2rem;
-  background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)),
-    url('/uploads/Introduction.jpg');
+  position: relative;
+  min-height: 60vh;
+  background-image: url('/uploads/Introduction.jpg');
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
-  color: white;
+}
+
+.overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(255, 255, 255, 0.7);
   display: flex;
-  flex-direction: column;
   justify-content: center;
   align-items: center;
-  min-height: 60vh;
+  text-align: center;
+  padding: 0 1rem;
+}
+
+.overlay-message {
+  font-size: 3rem;
+  color: #555;
 }
 </style>


### PR DESCRIPTION
## Summary
- add overlay div to HeroSection
- style overlay with dark grey message text

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68814ce0b008832cbcc19b673a666f65