### PR TITLE
Fix about bio format and profile layout

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -1,22 +1,5 @@
 ---
 name: Nidhi Gandhi
 photo: /uploads/profile.jpeg
-bio: |
-  With over 10 years of experience in therapy, I specialize in helping individuals navigate
-  challenges like depression, anxiety, trauma, grief, and relationship difficulties. My
-  approach is grounded in self-awareness and acceptance, empowering clients to break
-  free from limiting beliefs and reach their highest potential.
-  I believe in a holistic, client-centered approach to healing, integrating a variety of
-  therapeutic modalities, including Cognitive Behavioral Therapy (CBT), Dialectical
-  Behavioral Therapy (DBT), Solution-Focused Therapy, Psychodynamic Therapy, and
-  Emotion-Focused Therapy. By tailoring each session to the unique needs of my clients,
-  I help create lasting change and healthier, more fulfilling relationships.
-  As a trauma-informed therapist, I prioritize creating a warm, empathetic, 
-  and non-judgmental space for you to explore your emotions and experiences. I take pride in
-  offering culturally sensitive care, ensuring that all individuals feel understood and
-  respected in their journey toward healing.
-  If you’re facing overwhelming challenges or are ready to make meaningful changes in
-  your life, I’m here to support you every step of the way. Whether you’d like to book a
-  session or start with a free 15-minute consultation, I look forward to partnering with you
-  in your personal growth.
+bio: With over 10 years of experience in therapy, I specialize in helping individuals navigate challenges like depression, anxiety, trauma, grief, and relationship difficulties. My approach is grounded in self-awareness and acceptance, empowering clients to break free from limiting beliefs and reach their highest potential. I believe in a holistic, client-centered approach to healing, integrating a variety of therapeutic modalities, including Cognitive Behavioral Therapy (CBT), Dialectical Behavioral Therapy (DBT), Solution-Focused Therapy, Psychodynamic Therapy, and Emotion-Focused Therapy. By tailoring each session to the unique needs of my clients, I help create lasting change and healthier, more fulfilling relationships. As a trauma-informed therapist, I prioritize creating a warm, empathetic, and non-judgmental space for you to explore your emotions and experiences. I take pride in offering culturally sensitive care, ensuring that all individuals feel understood and respected in their journey toward healing. If you’re facing overwhelming challenges or are ready to make meaningful changes in your life, I’m here to support you every step of the way. Whether you’d like to book a session or start with a free 15-minute consultation, I look forward to partnering with you in your personal growth.
 ---

--- a/src/components/ProfileCard.vue
+++ b/src/components/ProfileCard.vue
@@ -1,8 +1,10 @@
 <template>
   <div class="profile">
-    <img :src="photo" alt="Profile" />
-    <h2>{{ name }}</h2>
-    <p>{{ bio }}</p>
+    <img :src="photo" alt="Profile" class="profile-photo" />
+    <div class="profile-text">
+      <h2 class="name">{{ name }}</h2>
+      <p class="bio-text">{{ bio }}</p>
+    </div>
   </div>
 </template>
 
@@ -12,12 +14,29 @@ defineProps(['photo', 'name', 'bio'])
 
 <style scoped>
 .profile {
-  text-align: center;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
   padding: 2rem;
 }
-img {
+
+.profile-photo {
   border-radius: 100px;
-  width: 150px;
+  width: 200px;
+  margin-right: 2rem;
   margin-bottom: 1rem;
+}
+
+.profile-text {
+  flex: 1 1 300px;
+}
+
+.name {
+  font-weight: 400;
+}
+
+.bio-text {
+  font-weight: 300;
+  color: #555;
 }
 </style>


### PR DESCRIPTION
## Summary
- simplify `about.md` front matter so `bio` parses correctly
- style profile layout with the photo on the left and bio on the right
- enlarge profile photo and lighten fonts with wrapping layout

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_688153c177c0832c950e1ed6c8f5f0c7