### PR TITLE
Improve service grid styling

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -132,10 +132,14 @@ nav a.active {
   font-weight: bold;
   font-size: 1.2rem;
 }
-.service-grid {
-  display: flex;
-  flex-wrap: wrap;
+#services.service-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
   gap: 1.5rem;
+  justify-items: center;
+  align-items: center;
+  min-height: 90vh;
+  width: 100%;
 }
 #about {
   min-height: 90vh;

--- a/src/components/ServiceCard.vue
+++ b/src/components/ServiceCard.vue
@@ -11,8 +11,11 @@ defineProps(['title', 'description'])
 
 <style scoped>
 .card {
-  background: #f9f9f9;
+  background: linear-gradient(135deg, #f5f7fa, #c3cfe2);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
   padding: 1rem;
   border-radius: 8px;
+  flex: 1 1 calc(30% - 1.5rem);
+  max-width: calc(30% - 1.5rem);
 }
 </style>


### PR DESCRIPTION
## Summary
- adjust ServiceCard style to use gradient background and shadow
- arrange services evenly using CSS grid and match section height to others

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_688158a60548832c9bdbae7f23aaaa50