### PR TITLE
Adjust service card layout

### DIFF
--- a/src/components/ServiceCard.vue
+++ b/src/components/ServiceCard.vue
@@ -13,9 +13,16 @@ defineProps(['title', 'description'])
 .card {
   background: linear-gradient(135deg, #f5f7fa, #c3cfe2);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
-  padding: 1rem;
+  padding: 2rem;
   border-radius: 8px;
-  flex: 1 1 calc(30% - 1.5rem);
-  max-width: calc(30% - 1.5rem);
+  width: 100%;
+}
+
+.card h3 {
+  font-size: 1.5rem;
+}
+
+.card p {
+  font-size: 1.1rem;
 }
 </style>


### PR DESCRIPTION
## Summary
- make service cards wider so they fill the services section
- enlarge text inside each card

## Testing
- `npm run build` *(fails: `vite` not found due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68815ae2c654832c8261ac514ddb7470