### PR TITLE
Make logo link navigate home

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,10 +1,10 @@
 <template>
   <div>
     <header class="navbar">
-      <div class="brand">
+      <a href="#hero" class="brand" @click="activeTab = 'hero'">
         <img src="/logo.png" alt="Soul Solace Therapy logo" class="logo" />
         <span class="title">Soul Solace Therapy</span>
-      </div>
+      </a>
       <nav>
         <a
           href="#hero"
@@ -130,6 +130,9 @@ nav a.active {
 .brand {
   display: flex;
   align-items: center;
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
 }
 .logo {
   height:50px;


### PR DESCRIPTION
## Summary
- make the site logo a link that resets the active tab to Home
- add link styling for the brand

## Testing
- `npm install` *(fails: registry.npmjs.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6883a3435300832c8aa891f64107968c