### PR TITLE
Add light green background and profile animation

### DIFF
--- a/src/components/ProfileCard.vue
+++ b/src/components/ProfileCard.vue
@@ -36,7 +36,8 @@ function scrollToServices() {
   display: flex;
   flex-wrap: wrap;
   align-items: stretch;
-  background: #839c7a;
+  background: #ffffff; /* white box */
+  animation: profile-emerge 1s ease-out;
   padding: 1rem;
   border-radius: 16px;
   box-shadow: 0 6px 16px rgba(0, 0, 0, 0.1);
@@ -105,6 +106,17 @@ function scrollToServices() {
 
   .profile-text {
     max-width: 90%;
+  }
+}
+
+@keyframes profile-emerge {
+  from {
+    transform: translateY(30px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
   }
 }
 </style>

--- a/src/style.css
+++ b/src/style.css
@@ -5,7 +5,7 @@
 
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  background-color: #e6f4e6; /* light green background */
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -68,7 +68,7 @@ button:focus-visible {
 @media (prefers-color-scheme: light) {
   :root {
     color: #213547;
-    background-color: #ffffff;
+    background-color: #e6f4e6; /* light green for light mode */
   }
   a:hover {
     color: #747bff;


### PR DESCRIPTION
## Summary
- apply light green background globally
- update ProfileCard to be white and animated

## Testing
- `npm install` *(fails: network disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6885419a05d8832c897b8993be229053