### PR TITLE
Add images to service cards

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -45,6 +45,7 @@
           :key="service.title"
           :title="service.title"
           :description="service.description"
+          :image="service.image"
         />
       </section>
       <section id="contact">
@@ -89,7 +90,10 @@ onMounted(async () => {
   const slugs = ['therapy', 'anxiety', 'couples']
   for (const slug of slugs) {
     const res = await fetch(`/content/services/${slug}.md`)
-    services.value.push(parseFrontMatter(await res.text()))
+    services.value.push({
+      ...parseFrontMatter(await res.text()),
+      image: 'https://via.placeholder.com/300x200?text=Service+Image',
+    })
   }
 
   const contactRes = await fetch('/content/contact.json')
@@ -147,7 +151,7 @@ nav a.active {
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
   gap: 2rem;
   justify-items: center;
-  align-items: center;
+  align-items: stretch;
   justify-content: space-evenly;
   align-content: space-evenly;
   min-height: 80vh;

--- a/src/components/ServiceCard.vue
+++ b/src/components/ServiceCard.vue
@@ -1,28 +1,51 @@
 <template>
   <div class="card">
-    <h3>{{ title }}</h3>
-    <p>{{ description }}</p>
+    <img :src="image" alt="Service image" class="service-image" />
+    <h3 class="service-title">{{ title }}</h3>
+    <p class="service-description">{{ description }}</p>
   </div>
 </template>
 
 <script setup>
-defineProps(['title', 'description'])
+defineProps({
+  title: String,
+  description: String,
+  image: {
+    type: String,
+    default: 'https://via.placeholder.com/300x200?text=Service+Image',
+  },
+})
 </script>
 
 <style scoped>
 .card {
   background: linear-gradient(135deg, #e3bfbf, #e3bfbf);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
-  padding: 2rem;
+  padding: 1.5rem;
   border-radius: 8px;
   width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  min-height: 350px;
 }
 
-.card h3 {
+.service-image {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+  border-radius: 4px;
+  margin-bottom: 1rem;
+}
+
+.service-title {
   font-size: 1.5rem;
+  margin-bottom: 0.5rem;
 }
 
-.card p {
+.service-description {
   font-size: 1.1rem;
 }
+
 </style>


### PR DESCRIPTION
## Summary
- show placeholder photos in ServiceCard
- feed placeholder image URLs to services in `App.vue`
- tweak service grid layout for equal card height

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883edacce80832cba28ff5951d70aa9