### PR TITLE
Pull service images from markdown

### DIFF
--- a/content/services/anxiety.md
+++ b/content/services/anxiety.md
@@ -1,4 +1,5 @@
 ---
 title: Anxiety Management
 description: Strategies and tools to manage anxiety, reduce overwhelm, and build emotional resilience.
+image: https://via.placeholder.com/300x200?text=Anxiety+Management
 ---

--- a/content/services/couples.md
+++ b/content/services/couples.md
@@ -1,4 +1,5 @@
 ---
 title: Couples Counseling
 description: Relationship-focused sessions to strengthen communication, resolve conflict, and deepen connection.
+image: https://via.placeholder.com/300x200?text=Couples+Counseling
 ---

--- a/content/services/therapy.md
+++ b/content/services/therapy.md
@@ -1,4 +1,5 @@
 ---
 title: Individual Therapy
 description: One-on-one sessions to explore personal challenges, emotions, and mental health goals in a safe, supportive space.
+image: https://via.placeholder.com/300x200?text=Individual+Therapy
 ---

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -37,6 +37,7 @@ collections:
     fields:
       - { label: "Title", name: "title", widget: "string" }
       - { label: "Description", name: "description", widget: "markdown" }
+      - { label: "Image", name: "image", widget: "image" }
 
 
   - name: "contact"

--- a/src/App.vue
+++ b/src/App.vue
@@ -90,10 +90,7 @@ onMounted(async () => {
   const slugs = ['therapy', 'anxiety', 'couples']
   for (const slug of slugs) {
     const res = await fetch(`/content/services/${slug}.md`)
-    services.value.push({
-      ...parseFrontMatter(await res.text()),
-      image: 'https://via.placeholder.com/300x200?text=Service+Image',
-    })
+    services.value.push(parseFrontMatter(await res.text()))
   }
 
   const contactRes = await fetch('/content/contact.json')

--- a/src/components/ServiceCard.vue
+++ b/src/components/ServiceCard.vue
@@ -19,7 +19,7 @@ defineProps({
 
 <style scoped>
 .card {
-  background: linear-gradient(135deg, #e3bfbf, #e3bfbf);
+  background: #839c7a;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
   padding: 1.5rem;
   border-radius: 8px;


### PR DESCRIPTION
## Summary
- use service image from markdown front matter
- update CMS config for service images
- match service card background color with navbar

## Testing
- `npm install` *(fails: network disabled)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68854804f1fc832cbe716e4ebf65d50e