### PR TITLE
Adjust service grid layout

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -146,7 +146,8 @@ nav a.active {
 }
 #services.service-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  /* Display exactly three service cards per row */
+  grid-template-columns: repeat(3, 1fr);
   gap: 2rem;
   justify-items: center;
   align-items: stretch;

--- a/src/components/ServiceCard.vue
+++ b/src/components/ServiceCard.vue
@@ -22,7 +22,8 @@ defineProps({
   background: #839c7a;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
   padding: 1.5rem;
-  border-radius: 8px;
+  /* More rounded corners for a softer look */
+  border-radius: 16px;
   width: 100%;
   display: flex;
   flex-direction: column;
@@ -35,7 +36,8 @@ defineProps({
   width: 100%;
   height: 200px;
   object-fit: cover;
-  border-radius: 4px;
+  /* Match the card's curvature */
+  border-radius: 12px;
   margin-bottom: 1rem;
 }
 


### PR DESCRIPTION
## Summary
- show services in fixed three-per-row layout
- round service card corners for a softer appearance

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68854fe3489c832c968bb97e872cdf7c