### PR TITLE
Adjust service grid gap

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -148,7 +148,8 @@ nav a.active {
   display: grid;
   /* Display exactly three service cards per row */
   grid-template-columns: repeat(3, 1fr);
-  gap: 2rem;
+  /* Provide a small gap between service cards */
+  gap: 1rem;
   justify-items: center;
   align-items: stretch;
   justify-content: space-evenly;


### PR DESCRIPTION
## Summary
- shrink spacing between ServiceCard boxes in the services section

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885524897d4832cb3020da89700a5b6