### PR TITLE
Enlarge hero button

### DIFF
--- a/src/components/HeroSection.vue
+++ b/src/components/HeroSection.vue
@@ -39,6 +39,7 @@ defineProps(['title', 'message'])
 
 .overlay-message {
   position: absolute;
+  left: 50%;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -49,7 +50,7 @@ defineProps(['title', 'message'])
   border-radius: 8px;
   box-shadow: 0 0 20px 4px #8ea387;
   animation: emerge 10s ease-out forwards;
-  transform: translateZ(-50px);
+  transform: translateX(-50%) translateZ(-50px) scale(2);
   font-size: large;
 }
 


### PR DESCRIPTION
## Summary
- tweak hero button to be twice as big and keep centered

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885da667950832cacaa1088638bcec9