### PR TITLE
feat: make hero message responsive

### DIFF
--- a/src/components/HeroSection.vue
+++ b/src/components/HeroSection.vue
@@ -67,8 +67,11 @@ defineProps(['title', 'message'])
 .guiding-light {
   position: absolute;
   top: 100%;
-  width: 75%;
-  font-size: xx-large;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100%;
+  max-width: 75%;
+  font-size: clamp(1.25rem, 3vw, 2.5rem);
   color: #a69c98;
   display: flex;
   justify-content: center;
@@ -76,6 +79,13 @@ defineProps(['title', 'message'])
   text-align: center;
   padding-top: 1rem;
   animation: slide-up-2 12s ease forwards;
+}
+
+@media (max-width: 768px) {
+  .guiding-light {
+    max-width: 90%;
+    font-size: clamp(1rem, 5vw, 2rem);
+  }
 }
 
 @keyframes slide-up-2 {


### PR DESCRIPTION
## Summary
- center hero tagline and let it span full width for consistent layout
- scale font size and width with viewport to keep text legible on any device

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6892fa8d5ee4832cb8aa55a2a2d09ffe