### PR TITLE
Scale Get Started button with screen size

### DIFF
--- a/src/components/HeroSection.vue
+++ b/src/components/HeroSection.vue
@@ -50,8 +50,8 @@ defineProps(['title', 'message'])
   border-radius: 8px;
   box-shadow: 0 0 20px 4px #8ea387;
   animation: emerge 10s ease-out forwards;
-  transform: translateX(-50%) translateZ(-50px) scale(1.3);
-  font-size: large;
+  transform: translateX(-50%) translateZ(-50px);
+  font-size: clamp(1rem, 2.5vw, 1.6rem);
 }
 
 @keyframes emerge {


### PR DESCRIPTION
## Summary
- make Get Started button responsive across viewports

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68930456b464832ca8ba8d652012af8b