### PR TITLE
Ensure content header spans full screen width

### DIFF
--- a/src/components/ProfileCard.vue
+++ b/src/components/ProfileCard.vue
@@ -155,9 +155,9 @@ function scrollToServices() {
 }
 
 .content-header {
-  display:flex;
+  display: flex;
   align-items: baseline;
-  width:100%;
+  width: 100vw;
 }
 
 .subtitle {


### PR DESCRIPTION
## Summary
- Adjust ProfileCard content header to span the full viewport width for proper alignment

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68930af42068832c83fdc970e4315d05